### PR TITLE
Persist store after importing data

### DIFF
--- a/Services/ExportImportService.swift
+++ b/Services/ExportImportService.swift
@@ -65,12 +65,15 @@ class ExportImportService: ObservableObject {
                 store.streak = importData.streak
                 store.settings = importData.settings
                 store.weeklySummaries = importData.weeklySummaries
-                
+
             case .merge:
                 // Merge logic - combine without duplicates
                 mergeData(from: importData, into: store)
             }
-            
+
+            // Persist imported changes regardless of merge policy
+            store.saveData()
+
             return true
         } catch {
             print("Import failed: \(error)")

--- a/Services/LocalStore.swift
+++ b/Services/LocalStore.swift
@@ -353,7 +353,7 @@ class LocalStore: ObservableObject {
     }
     
     // MARK: - Persistence
-    private func saveData() {
+    func saveData() {
         // Save to UserDefaults for simplicity (in production, use Core Data or Files)
                let encoder = JSONEncoder()
                


### PR DESCRIPTION
## Summary
- Ensure imported data is saved regardless of merge policy
- Expose LocalStore's saveData so import can persist changes

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689e194f02148330ba76aa28b3927f83